### PR TITLE
Removed game_id as primary key in hitchart table 

### DIFF
--- a/gameday.sql
+++ b/gameday.sql
@@ -104,7 +104,8 @@ CREATE TABLE `pitch` (
 
 DROP TABLE IF EXISTS `hitchart`;
 CREATE TABLE `hitchart` (
-	game_id varchar(30) not null primary key,
+	hit_id int unsigned not null auto_increment primary key,
+	game_id varchar(30) not null,
 	des varchar(25) default null,
 	x decimal(7,3) default null,
 	y decimal(7,3) default null,


### PR DESCRIPTION
game_id was removed as primary key so that newer hits in a game would not replace older ones. Before this change, only the the last hit of each game was being stored in the hitchart table.  Added auto increment primary key so that all hits from each game are stored.
