### PR TITLE
Add games called by rain but still in "Final" status

### DIFF
--- a/lib/game.py
+++ b/lib/game.py
@@ -20,15 +20,21 @@ class Game:
                     val = int(val)
                 else:
                     val = str(val)
-                
+
                 setattr(self, key, val)
 
     def save(self):
-        # make sure we have a status, said status is F(inal), and
-        # that we have a game_type
+        # make sure we have a status, said status is F(inal)
+        # or FR (Final, called by rain),
+        # and that we have a game_type
+        # (see
+        # http://gd2.mlb.com/components/game/mlb/year_2015/month_06/day_04/gid_2015_06_04_clemlb_kcamlb_1/boxscore.xml
+        # or
+        # http://gd2.mlb.com/components/game/mlb/year_2015/month_04/day_20/gid_2015_04_20_balmlb_bosmlb_1/boxscore.xml
+        # for examples)
         if self.status_ind and \
             self.game_type and \
-            self.status_ind == 'F':
+            (self.status_ind == 'F' or self.status_ind == 'FR'):
             DB = store.Store()
             sql = 'REPLACE INTO game (%s) VALUES(%s)' % (','.join(Game.FIELDS), ','.join(['%s'] * len(Game.FIELDS)))
             DB.query(sql, [getattr(self, field) for field in Game.FIELDS])
@@ -41,32 +47,32 @@ class Game:
         year, month, day = game_id.split('_')[1:4]
         url = '%syear_%s/month_%s/day_%s/%s/' % (CONSTANTS.BASE, year, month, day, game_id)
         soup = BeautifulSoup(Fetcher.fetch(url))
-        
+
         game_url = '%sgame.xml' % url
         game_contents = Fetcher.fetch(game_url)
 
         box_url = '%sboxscore.xml' % url
         contents = Fetcher.fetch(box_url)
-        
+
         linescore_url = '%slinescore.xml' % url
         linescore_contents = Fetcher.fetch(linescore_url)
-        
+
         if contents and linescore_contents and game_contents:
             doc = minidom.parseString(contents)
             line = minidom.parseString(linescore_contents)
             game_general = minidom.parseString(game_contents)
-            
+
             if game_general.getElementsByTagName('game').length==1:
                 game = game_general.getElementsByTagName('game').item(0)
                 self.local_game_time = game.attributes['local_game_time'].value
                 self.game_time_et = game.attributes['game_time_et'].value
-            
+
             if game_general.getElementsByTagName('stadium').length==1:
                 stadium = game_general.getElementsByTagName('stadium').item(0)
                 self.stadium_id = stadium.attributes['id'].value
                 self.stadium_name = stadium.attributes['name'].value
                 self.stadium_location = stadium.attributes['location'].value
-            
+
             if line.getElementsByTagName('game').length == 1:
                 game = line.getElementsByTagName('game').item(0)
                 self.game_type = game.attributes['game_type'].value
@@ -74,4 +80,3 @@ class Game:
 
             if doc.getElementsByTagName('boxscore').length == 1:
                 self._parseBox(doc.getElementsByTagName('boxscore').item(0))
-


### PR DESCRIPTION
Previously `game.py` only considered games with `status_ind="F"` to be final.
A number of games called by rain, but still long enough to be considered official, were missing
This affects stats when aggregated. As an example, the 2015 RBI total for David Ortiz and run total for Lorenzo Cain were off by one due to games they were in that ended in 'status_ind="FR"' (2016-04-20 for Ortiz and 2016-06-04 for Cain).